### PR TITLE
add norgate-av create-react-app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A collection of freely available community generated resources for working with 
 ### Frameworks/Templates
 * [Cres-Svelte-Tron](https://github.com/purebordem/Cres-Svelte-Tron)
   * Project template and build pipeline for Crestron CH-5 apps using the Svelte framework, Rollup, and Eruda
-* [Create-React-App-Template-CH5-Typescript](https://github.com/avspltd/cra-template-ch5-typescript)
+* [Create-React-App-Template-CH5-Typescript #1](https://github.com/avspltd/cra-template-ch5-typescript)
   * TypeScript template for Create React App and Crestron CH5
-* [Create-React-App-Template-CH5-Typescript](https://github.com/Norgate-AV-Solutions-Ltd/cra-template-crestron-ch5-typescript)
+* [Create-React-App-Template-CH5-Typescript #2](https://github.com/Norgate-AV-Solutions-Ltd/cra-template-crestron-ch5-typescript)
   * TypeScript template for Create React App and Crestron CH5
 * [CH5-Vue](https://github.com/utroda/ch5-vue) 
   * Project starter for VueJS + Crestron Ch5 with Vue Router and Vuex

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A collection of freely available community generated resources for working with 
   * Project template and build pipeline for Crestron CH-5 apps using the Svelte framework, Rollup, and Eruda
 * [Create-React-App-Template-CH5-Typescript](https://github.com/avspltd/cra-template-ch5-typescript)
   * TypeScript template for Create React App and Crestron CH5
+* [Create-React-App-Template-CH5-Typescript](https://github.com/Norgate-AV-Solutions-Ltd/cra-template-crestron-ch5-typescript)
+  * TypeScript template for Create React App and Crestron CH5
 * [CH5-Vue](https://github.com/utroda/ch5-vue) 
   * Project starter for VueJS + Crestron Ch5 with Vue Router and Vuex
 * [CH5xWeb-Vue](https://github.com/jvallon/ch5-vue-demo)


### PR DESCRIPTION
Hi,

I've been developing a Create-React-App template that I think is worth adding to the list.

Label wise I wasn't sure what to call it as it's another Typescript template. I have left it the same so there are two options. Can always update the labels to differentiate between them if you would prefer that.

Thanks,

D 