### PR TITLE
docs(readme.md): add crestron-ch5-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A collection of freely available community generated resources for working with 
 ### Modules
 * [Crestron-Fonts](https://github.com/alvaroyurrita/Crestron-Fonts)
   * SmartGraphics Theme Transport Icons turned into Vectorized Fonts. Can be infinitely enlarged, rotated, colored, animated etc. using CSS styles.
+* [Crestron-CH5-Helper](https://github.com/Norgate-AV-Solutions-Ltd/crestron-ch5-helper)
+  * A collection of Crestron CH5 constants.
 
 ### Examples
 * [Basic CH5 #1](https://github.com/Mirage-AV/Crestron-CH5-Basic)


### PR DESCRIPTION
I recently published this helper library to NPM. It defines all the CH5 signal types and also all the CH5 reserved joins.